### PR TITLE
PEP8 fixes

### DIFF
--- a/core.py
+++ b/core.py
@@ -1,30 +1,29 @@
 import logging
+
 import meetup.api
-from datetime import datetime, timedelta
+
 from config import target
 from timeutils import meetup_time, meetup_duration
 
 logger = logging.getLogger(__name__)
 
 
-def _importAPIKey():
+def _import_api_key():
     with open('config/apikey.txt', 'r') as file:
         key = file.readline().strip()
 
     return key
 
 
-def _initClient(apiKey):
-    return meetup.api.Client(apiKey)
+def _init_client(api_key):
+    return meetup.api.Client(api_key)
 
 
-def _initTargetData(client, isDev):
+def _init_target_data(client, is_dev):
     """Returns dict of parameters for request target"""
-    _data = {}
+    _data = {'group_urlname': target.URL_NAME}
 
-    _data['group_urlname'] = target.URL_NAME
-
-    if isDev:
+    if is_dev:
         _data['group_urlname'] = "Meetup-API-Testing"
 
     group_info = client.GetGroup(urlname=_data['group_urlname'])
@@ -33,7 +32,6 @@ def _initTargetData(client, isDev):
     _data['venue_id'] = target.VENUE
 
     return _data
-
 
 
 def update_event_data(data):
@@ -49,11 +47,11 @@ def create_event(event_data, is_dev):
     """Sends request to meetup to create event with given event_data"""
 
     logger.info('create meetup client')
-    api_key = _importAPIKey()
-    client = _initClient(api_key)
+    api_key = _import_api_key()
+    client = _init_client(api_key)
 
     logger.info('create request parameters')
-    target_data = _initTargetData(client, is_dev)
+    target_data = _init_target_data(client, is_dev)
 
     logger.debug(event_data)
     event_data = update_event_data(event_data)

--- a/main.py
+++ b/main.py
@@ -1,8 +1,10 @@
 import logging
-from datetime import datetime
+
 import click
-from utility import readYAML
+
 from core import create_event
+from utility import read_yaml
+
 
 @click.group()
 def main():
@@ -10,17 +12,26 @@ def main():
 
     Now go! Add some events!
     """
-    logging.basicConfig(filename='inf_event_cli.log', level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logging.basicConfig(
+        filename='inf_event_cli.log',
+        level=logging.DEBUG,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
     logging.info('start')
 
 
 @main.command()
 @click.argument('event_file', metavar='<file.yml>')
-@click.option('--dev', is_flag=True, help="Uses Meetup Testing API group, insted of target group.")
+@click.option(
+    '--dev',
+    is_flag=True,
+    help="Uses Meetup Testing API group, instead of target group."
+)
 def add(event_file, dev):
     """Publishes event on Meetup"""
-    event_data = readYAML(event_file)
+    event_data = read_yaml(event_file)
     create_event(event_data, dev)
+
 
 @main.command()
 @click.argument('key')

--- a/timeutils.py
+++ b/timeutils.py
@@ -1,9 +1,11 @@
 import logging
-from datetime import timedelta, timezone, datetime
+from datetime import timedelta, timezone
+
 logger = logging.getLogger(__name__)
 
 MEETUP_TZ = timezone(timedelta(hours=-4))
 HS_TZ = timezone(timedelta(hours=2))
+
 
 def meetup_time(dt):
     """Converts time to format accepted by meetup API"""
@@ -11,27 +13,27 @@ def meetup_time(dt):
     logger.info('change timezone')
     dt = dt.replace(tzinfo=HS_TZ)
     logger.debug("%s, %s", dt, dt.timestamp())
-    result = datetime2ms(dt)
+    result = datetime_to_ms(dt)
     return {'time': result}
 
 
 def meetup_duration(td):
     """Converts duration to format accepted by meetup API"""
-    result = timedelta2ms(td)
+    result = timedelta_to_ms(td)
     return {'duration': result}
 
 
-def sec2ms(sec):
+def sec_to_ms(sec):
     return int(sec * 1000)
 
 
-def datetime2ms(dt):
+def datetime_to_ms(dt):
     """Converts datetime to milliseconds"""
-    ms = sec2ms(dt.timestamp())
+    ms = sec_to_ms(dt.timestamp())
     return ms
 
 
-def timedelta2ms(td):
+def timedelta_to_ms(td):
     """Converts timedelta to milliseconds"""
-    ms = sec2ms(td.total_seconds())
+    ms = sec_to_ms(td.total_seconds())
     return ms

--- a/utility.py
+++ b/utility.py
@@ -1,8 +1,11 @@
 import logging
+
 import yaml
+
 logger = logging.getLogger(__name__)
 
-def readYAML(filename):
+
+def read_yaml(filename):
     """Returns dict of parsed data from file"""
     with open(filename, 'r') as stream:
         try:


### PR DESCRIPTION
This PR fixes #20

* Group imports according to PEP8
* Remove unused imports
* Rename functions/variables using `snake_case`
* Fix typo: `insted` -> `instead`
* Two blank lines above top-level definitions
* Reformat lines > 79 characters long